### PR TITLE
Add ASDF support

### DIFF
--- a/Load Builder.lisp
+++ b/Load Builder.lisp
@@ -1,5 +1,6 @@
 ;; Options: :avr :arm :msp430 :esp :stm32 :badge :zero :riscv
 
+#+lispworks
 (push :esp *features*)
  
 ;***************************************
@@ -25,6 +26,14 @@
 (push :code *features*)
 
 
-(load "/Users/david/Projects/Builder/builder defsys.lisp")
+#+lispworks
+(progn
+  (load "/Users/david/Projects/Builder/builder defsys.lisp")
+  (compile-system "builder" :load t))
 
-(compile-system "builder" :load t) 
+#-lispworks
+(progn
+  (require "asdf")
+  (defvar *this-directory* (uiop:pathname-directory-pathname *load-pathname*))
+  (pushnew *this-directory* asdf:*central-registry* :test 'equal)
+  (asdf:load-system "ulisp-builder"))

--- a/README.md
+++ b/README.md
@@ -4,3 +4,25 @@ Builds a version of uLisp for a particular platform from a common repository of 
 Currently supports the AVR, ARM, ESP8266/32, and RISC-V platforms.
 
 For information see http://www.ulisp.com/show?3F07.
+
+# Using
+
+Instructions:
+
+1. Start REPL.
+
+2. Push desired platform to `*features*`:
+
+   `(push :badge *features*)`
+
+   See header of `Load Builder.lisp` for full list of platforms.
+
+3. Load builder:
+
+   `(load "Load Builder")`
+
+4. Run builder:
+
+   `(build :badge)`
+
+Builder will create `ulisp.ino` alongside `Load Builder.lisp`.

--- a/build.lisp
+++ b/build.lisp
@@ -95,7 +95,9 @@
                   (t (write-no-comments str inc comments)))))
               (t nil)))))
     ;;           
-  (with-open-file (str (capi:prompt-for-file "Output File" :operation :save :pathname "/Users/david/Desktop/") :direction :output)
+  (with-open-file (str #+lispworks (capi:prompt-for-file "Output File" :operation :save :pathname "/Users/david/Desktop/")
+                       #-lispworks (merge-pathnames "ulisp.ino" *this-directory*)
+                       :direction :output)
     ;; Write preamble
     ; (include :header str)
     (write-no-comments str (eval (intern (format nil "*~a-~a*" :header platform) :cl-user)) t)

--- a/package.lisp
+++ b/package.lisp
@@ -1,0 +1,4 @@
+;;;; package.lisp
+
+(defpackage #:ulisp-builder
+  (:use #:common-lisp))

--- a/ulisp-builder.asd
+++ b/ulisp-builder.asd
@@ -1,0 +1,22 @@
+;;;; ulisp-builder.asd
+
+(asdf:defsystem #:ulisp-builder
+  :description "Produce uLisp Arduino source code"
+  :author "David Johnson-Davies <david@interface.co.uk>"
+  :license "MIT"
+  :version "3.6"
+  :serial t
+  :components ((:file "extras")
+               (:file "functions")
+               (:file "preface")
+               (:file "utilities")
+               (:file "saveload")
+               (:file "prettyprint")
+               (:file "assembler")
+               (:file "postscript")
+               (:file "avr")
+               (:file "arm")
+               (:file "esp")
+               (:file "riscv")
+               (:file "badge")
+               (:file "build")))

--- a/ulisp-builder.lisp
+++ b/ulisp-builder.lisp
@@ -1,0 +1,3 @@
+;;;; ulisp-builder.lisp
+
+(in-package #:ulisp-builder)


### PR DESCRIPTION
These patches add support for running `ulisp-builder` on SBCL and other Lisp implementations that provide ASDF.